### PR TITLE
Add missing arg for chunk size

### DIFF
--- a/src/dicomweb_client/cli.py
+++ b/src/dicomweb_client/cli.py
@@ -62,6 +62,10 @@ def _get_parser():
         '--url', dest='url', metavar='URL',
         help='uniform resource locator of the DICOMweb service'
     )
+    parser.add_argument(
+        '--chunk_size', dest='chunk_size', metavar='CHUNK_SIZE',
+        help='maximum size of a network transfer chunk'
+    )
 
     abstract_optional_study_parser = argparse.ArgumentParser(add_help=False)
     abstract_optional_study_parser.add_argument(


### PR DESCRIPTION
This argument seemed to be missing.

When I added this arg I was able to use the chunk size and confirm it works for google's dicomweb endpoints.

```
 $ dicomweb_client --chunk_size 10 --url $URL --token $(token) search studies > /tmp/10
$ dicomweb_client  --url $URL --token $(token) search studies > /tmp/x
$ diff /tmp/x /tmp/10
$
```