### PR TITLE
Add generator based download of studies/series

### DIFF
--- a/src/dicomweb_client/api.py
+++ b/src/dicomweb_client/api.py
@@ -13,7 +13,7 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Iterable,
+    Iterator,
     List,
     Optional,
     Set,
@@ -768,7 +768,7 @@ class DICOMwebClient(object):
     def _decode_multipart_message(
             self,
             response: requests.Response
-        ) -> Iterable[bytes]:
+        ) -> Iterator[bytes]:
         '''Yields extracted parts of a HTTP multipart response message.
 
         Parameters
@@ -778,7 +778,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        Iterable[bytes]
+        Iterator[bytes]
             message parts
 
         '''
@@ -1049,7 +1049,7 @@ class DICOMwebClient(object):
             url: str,
             media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
             params: Optional[Dict[str, Any]] = None
-        ) -> Iterable[pydicom.dataset.Dataset]:
+        ) -> Iterator[pydicom.dataset.Dataset]:
         '''Performs a HTTP GET request that accepts a multipart message with
         "applicaton/dicom" media type.
 
@@ -1066,7 +1066,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        Iterable[pydicom.dataset.Dataset]
+        Iterator[pydicom.dataset.Dataset]
             DICOM data sets
 
         '''
@@ -1111,7 +1111,7 @@ class DICOMwebClient(object):
             media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
             byte_range: Optional[Tuple[int, int]] = None,
             params: Optional[Dict[str, Any]] = None
-        ) -> Iterable[bytes]:
+        ) -> Iterator[bytes]:
         '''Performs a HTTP GET request that accepts a multipart message with
         "applicaton/octet-stream" media type.
 
@@ -1130,7 +1130,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        Iterable[bytes]
+        Iterator[bytes]
             content of HTTP message body parts
 
         '''
@@ -1158,7 +1158,7 @@ class DICOMwebClient(object):
             byte_range: Optional[Tuple[int, int]] = None,
             params: Optional[Dict[str, Any]] = None,
             rendered: bool = False
-        ) -> Iterable[bytes]:
+        ) -> Iterator[bytes]:
         '''Performs a HTTP GET request that accepts a multipart message with
         an image media type.
 
@@ -1178,7 +1178,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        Iterable[bytes]
+        Iterator[bytes]
             content of HTTP message body parts
 
         '''
@@ -1223,7 +1223,7 @@ class DICOMwebClient(object):
             byte_range: Optional[Tuple[int, int]] = None,
             params: Optional[Dict[str, Any]] = None,
             rendered: bool = False
-        ) -> Iterable[bytes]:
+        ) -> Iterator[bytes]:
         '''Performs a HTTP GET request that accepts a multipart message with
         a video media type.
 
@@ -1243,7 +1243,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        Iterable[bytes]
+        Iterator[bytes]
             content of HTTP message body parts
 
         '''
@@ -1697,7 +1697,7 @@ class DICOMwebClient(object):
             url: str,
             media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
             byte_range: Optional[Tuple[int, int]] = None
-        ) -> List[bytes]:
+        ) -> Iterator[bytes]:
         '''Retrieves bulk data from a given location.
 
         Parameters
@@ -1712,37 +1712,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        List[bytes]
-            bulk data items
-
-        '''
-        return list(
-            self.retrieve_bulkdata_iter(
-                url, media_types=media_types, byte_range=byte_range
-            )
-        )
-
-    def retrieve_bulkdata_iter(
-            self,
-            url: str,
-            media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
-            byte_range: Optional[Tuple[int, int]] = None
-        ) -> Iterable[bytes]:
-        '''Retrieves bulk data from a given location.
-
-        Parameters
-        ----------
-        url: str
-            location of the bulk data
-        media_types: Tuple[Union[str, Tuple[str, str]]], optional
-            acceptable media types and optionally the UIDs of the
-            corresponding transfer syntaxes
-        byte_range: Tuple[int], optional
-            start and end of byte range
-
-        Returns
-        -------
-        Iterable[bytes]
+        Iterator[bytes]
             bulk data items
 
         '''
@@ -1769,7 +1739,7 @@ class DICOMwebClient(object):
             self,
             study_instance_uid: str,
             media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
-        ) -> List[pydicom.dataset.Dataset]:
+        ) -> Iterator[pydicom.dataset.Dataset]:
         '''Retrieves instances of a given DICOM study.
 
         Parameters
@@ -1782,34 +1752,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        List[pydicom.dataset.Dataset]
-            data sets
-
-        '''
-        return list(
-            self.retrieve_study_iter(
-                study_instance_uid, media_types=media_types
-            )
-        )
-
-    def retrieve_study_iter(
-            self,
-            study_instance_uid: str,
-            media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
-        ) -> Iterable[pydicom.dataset.Dataset]:
-        '''Retrieves instances of a given DICOM study.
-
-        Parameters
-        ----------
-        study_instance_uid: str
-            unique study identifier
-        media_types: Tuple[Union[str, Tuple[str, str]]], optional
-            acceptable media types and optionally the UIDs of the
-            corresponding transfer syntaxes
-
-        Returns
-        -------
-        Iterable[pydicom.dataset.Dataset]
+        Iterator[pydicom.dataset.Dataset]
             data sets
 
         '''
@@ -1976,7 +1919,7 @@ class DICOMwebClient(object):
             study_instance_uid: str,
             series_instance_uid: str,
             media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
-        ) -> List[pydicom.dataset.Dataset]:
+        ) -> Iterator[pydicom.dataset.Dataset]:
         '''Retrieves instances of a given DICOM series.
 
         Parameters
@@ -1991,37 +1934,7 @@ class DICOMwebClient(object):
 
         Returns
         -------
-        List[pydicom.dataset.Dataset]
-            data sets
-
-        '''
-        return list(
-            self.retrieve_series_iter(
-                study_instance_uid, series_instance_uid, media_types=media_types
-            )
-        )
-
-    def retrieve_series_iter(
-            self,
-            study_instance_uid: str,
-            series_instance_uid: str,
-            media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
-        ) -> Iterable[pydicom.dataset.Dataset]:
-        '''Retrieves instances of a given DICOM series.
-
-        Parameters
-        ----------
-        study_instance_uid: str
-            unique study identifier
-        series_instance_uid: str
-            unique series identifier
-        media_types: Tuple[Union[str, Tuple[str, str]]], optional
-            acceptable media types and optionally the UIDs of the
-            corresponding transfer syntaxes
-
-        Returns
-        -------
-        Iterable[pydicom.dataset.Dataset]
+        Iterator[pydicom.dataset.Dataset]
             data sets
 
         '''

--- a/src/dicomweb_client/api.py
+++ b/src/dicomweb_client/api.py
@@ -1769,7 +1769,7 @@ class DICOMwebClient(object):
             self,
             study_instance_uid: str,
             transfer_syntax_uids: Optional[Tuple[str]] = None
-        ) -> Iterator[pydicom.dataset.Dataset]:
+        ) -> Iterator[bytes]:
         '''Retrieves bulk data of a given DICOM study.
 
         Parameters
@@ -1979,8 +1979,8 @@ class DICOMwebClient(object):
             study_instance_uid: str,
             series_instance_uid: str,
             transfer_syntax_uids: Optional[Tuple[str]] = None
-        ) -> Iterator[pydicom.dataset.Dataset]:
-        '''Retrieves instances of a given DICOM series.
+        ) -> Iterator[bytes]:
+        '''Retrieves bulk data of a given DICOM series.
 
         Parameters
         ----------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -333,7 +333,7 @@ def test_retrieve_instance_metadata_wado_prefix(httpserver, client, cache_dir):
     assert request.path == expected_path
 
 
-def test_retrieve_series(httpserver, client, cache_dir):
+def test_retrieve_series(client, httpserver, cache_dir):
     cache_filename = str(cache_dir.joinpath('file.dcm'))
     with open(cache_filename, 'rb') as f:
         payload = f.read()
@@ -354,45 +354,7 @@ def test_retrieve_series(httpserver, client, cache_dir):
     study_instance_uid = '1.2.3'
     series_instance_uid = '1.2.4'
     sop_instance_uid = '1.2.5'
-    results = client.retrieve_series(study_instance_uid, series_instance_uid)
-    assert isinstance(results, list)
-    assert len(results) == 3
-    for result in results:
-        with BytesIO() as fp:
-            pydicom.dcmwrite(fp, result)
-            raw_result = fp.getvalue()
-        assert raw_result == payload
-    request = httpserver.requests[0]
-    expected_path = (
-        '/studies/{study_instance_uid}/series/{series_instance_uid}'
-        .format(**locals())
-    )
-    assert request.path == expected_path
-    assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
-
-
-def test_retrieve_series_iter(client, httpserver, cache_dir):
-    cache_filename = str(cache_dir.joinpath('file.dcm'))
-    with open(cache_filename, 'rb') as f:
-        payload = f.read()
-    content = b''
-    for i in range(3):
-        content += b'\r\n--boundary\r\n'
-        content += b'Content-Type: application/dicom\r\n\r\n'
-        content += payload
-    content += b'\r\n--boundary--'
-    headers = {
-        'content-type': (
-            'multipart/related; '
-            'type="application/dicom"; '
-            'boundary="boundary" '
-        ),
-    }
-    httpserver.serve_content(content=content, code=200, headers=headers)
-    study_instance_uid = '1.2.3'
-    series_instance_uid = '1.2.4'
-    sop_instance_uid = '1.2.5'
-    results = client.retrieve_series_iter(
+    results = client.retrieve_series(
         study_instance_uid, series_instance_uid
     )
     assert inspect.isgenerator(results)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 import xml.etree.ElementTree as ET
 from io import BytesIO
@@ -357,7 +356,6 @@ def test_retrieve_series(client, httpserver, cache_dir):
     results = client.retrieve_series(
         study_instance_uid, series_instance_uid
     )
-    assert inspect.isgenerator(results)
     results = list(results)
     assert len(results) == 3
     for result in results:
@@ -504,7 +502,7 @@ def test_retrieve_instance_frames_jpeg(httpserver, client, cache_dir):
         study_instance_uid, series_instance_uid, sop_instance_uid,
         frame_numbers, media_types=('image/jpeg', )
     )
-    assert result == [content]
+    assert list(result) == [content]
     request = httpserver.requests[0]
     expected_path = (
         '/studies/{study_instance_uid}/series/{series_instance_uid}/instances'
@@ -555,7 +553,7 @@ def test_retrieve_instance_frames_jp2(httpserver, client, cache_dir):
         study_instance_uid, series_instance_uid, sop_instance_uid,
         frame_numbers, media_types=('image/jp2', )
     )
-    assert result == [content]
+    assert list(result) == [content]
     request = httpserver.requests[0]
     expected_path = (
         '/studies/{study_instance_uid}/series/{series_instance_uid}/instances'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -371,9 +371,7 @@ def test_retrieve_series(httpserver, client, cache_dir):
     assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
 
 
-def test_retrieve_series_iter(httpserver, cache_dir):
-    client = DICOMwebClient(httpserver.url, retrieve_iter=True)
-
+def test_retrieve_series_iter(client, httpserver, cache_dir):
     cache_filename = str(cache_dir.joinpath('file.dcm'))
     with open(cache_filename, 'rb') as f:
         payload = f.read()
@@ -394,7 +392,9 @@ def test_retrieve_series_iter(httpserver, cache_dir):
     study_instance_uid = '1.2.3'
     series_instance_uid = '1.2.4'
     sop_instance_uid = '1.2.5'
-    results = client.retrieve_series(study_instance_uid, series_instance_uid)
+    results = client.retrieve_series_iter(
+        study_instance_uid, series_instance_uid
+    )
     assert inspect.isgenerator(results)
     results = list(results)
     assert len(results) == 3

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -415,9 +415,7 @@ def test_retrieve_instance_any_transfer_syntax(httpserver, client, cache_dir):
     sop_instance_uid = '1.2.5'
     client.retrieve_instance(
         study_instance_uid, series_instance_uid, sop_instance_uid,
-        media_types=(
-            ('application/dicom', '*', ),
-        )
+        transfer_syntax_uids=('*', )
     )
     request = httpserver.requests[0]
     assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
@@ -437,9 +435,7 @@ def test_retrieve_instance_default_transfer_syntax(httpserver, client,
     sop_instance_uid = '1.2.5'
     client.retrieve_instance(
         study_instance_uid, series_instance_uid, sop_instance_uid,
-        media_types=(
-            ('application/dicom', '1.2.840.10008.1.2.1', ),
-        )
+        transfer_syntax_uids=('1.2.840.10008.1.2.1', )
     )
     request = httpserver.requests[0]
     assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
@@ -459,29 +455,7 @@ def test_retrieve_instance_wrong_transfer_syntax(httpserver, client, cache_dir):
     with pytest.raises(ValueError):
         client.retrieve_instance(
             study_instance_uid, series_instance_uid, sop_instance_uid,
-            media_types=(
-                ('application/dicom', '1.2.3', ),
-            )
-        )
-
-
-def test_retrieve_instance_wrong_mime_type(httpserver, client, cache_dir):
-    cache_filename = str(cache_dir.joinpath('file.dcm'))
-    with open(cache_filename, 'rb') as f:
-        content = f.read()
-    headers = {
-        'content-type': 'multipart/related; type="image/dicom"',
-    }
-    httpserver.serve_content(content=content, code=200, headers=headers)
-    study_instance_uid = '1.2.3'
-    series_instance_uid = '1.2.4'
-    sop_instance_uid = '1.2.5'
-    with pytest.raises(ValueError):
-        client.retrieve_instance(
-            study_instance_uid, series_instance_uid, sop_instance_uid,
-            media_types=(
-                ('image/dicom', '1.2.840.10008.1.2.1', ),
-            )
+            transfer_syntax_uids=('1.2.3', ),
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-import os
+import inspect
 import json
 import xml.etree.ElementTree as ET
 from io import BytesIO
@@ -331,6 +331,85 @@ def test_retrieve_instance_metadata_wado_prefix(httpserver, client, cache_dir):
         '/instances/{sop_instance_uid}/metadata'.format(**locals())
     )
     assert request.path == expected_path
+
+
+def test_retrieve_series(httpserver, client, cache_dir):
+    cache_filename = str(cache_dir.joinpath('file.dcm'))
+    with open(cache_filename, 'rb') as f:
+        payload = f.read()
+    content = b''
+    for i in range(3):
+        content += b'\r\n--boundary\r\n'
+        content += b'Content-Type: application/dicom\r\n\r\n'
+        content += payload
+    content += b'\r\n--boundary--'
+    headers = {
+        'content-type': (
+            'multipart/related; '
+            'type="application/dicom"; '
+            'boundary="boundary" '
+        ),
+    }
+    httpserver.serve_content(content=content, code=200, headers=headers)
+    study_instance_uid = '1.2.3'
+    series_instance_uid = '1.2.4'
+    sop_instance_uid = '1.2.5'
+    results = client.retrieve_series(study_instance_uid, series_instance_uid)
+    assert isinstance(results, list)
+    assert len(results) == 3
+    for result in results:
+        with BytesIO() as fp:
+            pydicom.dcmwrite(fp, result)
+            raw_result = fp.getvalue()
+        assert raw_result == payload
+    request = httpserver.requests[0]
+    expected_path = (
+        '/studies/{study_instance_uid}/series/{series_instance_uid}'
+        .format(**locals())
+    )
+    assert request.path == expected_path
+    assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
+
+
+def test_retrieve_series_iter(httpserver, cache_dir):
+    client = DICOMwebClient(httpserver.url, retrieve_iter=True)
+
+    cache_filename = str(cache_dir.joinpath('file.dcm'))
+    with open(cache_filename, 'rb') as f:
+        payload = f.read()
+    content = b''
+    for i in range(3):
+        content += b'\r\n--boundary\r\n'
+        content += b'Content-Type: application/dicom\r\n\r\n'
+        content += payload
+    content += b'\r\n--boundary--'
+    headers = {
+        'content-type': (
+            'multipart/related; '
+            'type="application/dicom"; '
+            'boundary="boundary" '
+        ),
+    }
+    httpserver.serve_content(content=content, code=200, headers=headers)
+    study_instance_uid = '1.2.3'
+    series_instance_uid = '1.2.4'
+    sop_instance_uid = '1.2.5'
+    results = client.retrieve_series(study_instance_uid, series_instance_uid)
+    assert inspect.isgenerator(results)
+    results = list(results)
+    assert len(results) == 3
+    for result in results:
+        with BytesIO() as fp:
+            pydicom.dcmwrite(fp, result)
+            raw_result = fp.getvalue()
+        assert raw_result == payload
+    request = httpserver.requests[0]
+    expected_path = (
+        '/studies/{study_instance_uid}/series/{series_instance_uid}'
+        .format(**locals())
+    )
+    assert request.path == expected_path
+    assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
 
 
 def test_retrieve_instance(httpserver, client, cache_dir):


### PR DESCRIPTION
Resolves #23 

- Added new client init kwarg `retrieve_iter=False` (to enable backwards-compatibility)
- If `retrieve_iter` is enabled, `retrieve_bulkdata`, `_study` and `_series` returns a generator
- Added tests for both old and new return types using `retrieve_series`

Note that custom multipart decoding was chosen because AFAICT both [email](https://github.com/python/cpython/blob/master/Lib/email/parser.py#L52) and [requests.toolbelt](https://github.com/requests/toolbelt/blob/0.9.1/requests_toolbelt/multipart/decoder.py#L153) loads everything into memory, and I'm not aware of other alternatives yet.