### PR TITLE
Allow single-part response for retrieve instance

### DIFF
--- a/src/dicomweb_client/api.py
+++ b/src/dicomweb_client/api.py
@@ -1065,7 +1065,7 @@ class DICOMwebClient(object):
         # Supplement 183 as part of re-documentation efforts, which stated that
         # this behavior was allowed. We will support this behavior at least
         # until the standard is fixed via a Correction Proposal 2040.
-        if response.headers['Content-Type'] == 'application/dicom':
+        if response.headers['Content-Type'].startswith('application/dicom'):
             logger.error(
                 'message sent by origin server in response to retrieve '
                 'instance request was not compliant with the standard, '

--- a/src/dicomweb_client/api.py
+++ b/src/dicomweb_client/api.py
@@ -1066,11 +1066,14 @@ class DICOMwebClient(object):
         # this behavior was allowed. We will support this behavior at least
         # until the standard is fixed via a Correction Proposal 2040.
         if response.headers['Content-Type'].startswith('application/dicom'):
-            logger.error(
-                'message sent by origin server in response to retrieve '
-                'instance request was not compliant with the standard, '
-                'message body shall have "multipart/related" Content-Type'
+            warning_message = (
+                'message sent by origin server in response to GET request '
+                'of Retrieve Instance transaction was not compliant with the '
+                'DICOM standard, message body shall have Content-Type '
+                '\'multipart/related; type="application/dicom"\' rather than '
+                '"application/dicom"'
             )
+            warn(warning_message, category=UserWarning)
             part = pydicom.dcmread(BytesIO(response.content))
             return iter([part])
         return (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -478,6 +478,28 @@ def test_retrieve_instance(httpserver, client, cache_dir):
     assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
 
 
+def test_retrieve_instance_singlepart(httpserver, client, cache_dir):
+    cache_filename = str(cache_dir.joinpath('file.dcm'))
+    with open(cache_filename, 'rb') as f:
+        data = f.read()
+    headers = {
+        'content-type': 'application/dicom'
+    }
+    httpserver.serve_content(content=data, code=200, headers=headers)
+    study_instance_uid = '1.2.3'
+    series_instance_uid = '1.2.4'
+    sop_instance_uid = '1.2.5'
+    response = client.retrieve_instance(
+        study_instance_uid, series_instance_uid, sop_instance_uid
+    )
+    with BytesIO() as fp:
+        pydicom.dcmwrite(fp, response)
+        raw_result = fp.getvalue()
+    assert raw_result == data
+    request = httpserver.requests[0]
+    assert request.accept_mimetypes[0][0].startswith('multipart/related')
+
+
 def test_retrieve_instance_any_transfer_syntax(httpserver, client, cache_dir):
     cache_filename = str(cache_dir.joinpath('file.dcm'))
     with open(cache_filename, 'rb') as f:


### PR DESCRIPTION
Some origin servers respond to retrieve instance requests with a message containing only a single part. While this is not compliant with the standard, the client should be able to handle this behavior. It will log an error message to make users aware of the standard compliance issue.