### PR TITLE
Fix type hint for pydicom Tag in `DICOMwebClient.lookup_keyword()`.

### DIFF
--- a/src/dicomweb_client/api.py
+++ b/src/dicomweb_client/api.py
@@ -2987,13 +2987,13 @@ class DICOMwebClient(object):
 
     @staticmethod
     def lookup_keyword(
-        tag: Union[str, int, Tuple[str, str], pydicom.tag.Tag]
+        tag: Union[str, int, Tuple[str, str], pydicom.tag.BaseTag]
     ) -> str:
         """Looks up the keyword of a DICOM attribute.
 
         Parameters
         ----------
-        tag: Union[str, int, Tuple[str, str], pydicom.tag.Tag]
+        tag: Union[str, int, Tuple[str, str], pydicom.tag.BaseTag]
             attribute tag (e.g. ``"00080018"``)
 
         Returns


### PR DESCRIPTION
The current [`Tag`](https://github.com/pydicom/pydicom/blob/4dee753ab82ccd7b248893e6d633ba20e7f81d99/pydicom/tag.py#L39) type hint refers to a method. Changed to point to the [`BaseTag`](https://github.com/pydicom/pydicom/blob/4dee753ab82ccd7b248893e6d633ba20e7f81d99/pydicom/tag.py#L140) class instead.