### PR TITLE
Support "permissive" UIDs in `URI`.

### DIFF
--- a/src/dicomweb_client/uri.py
+++ b/src/dicomweb_client/uri.py
@@ -221,6 +221,11 @@ class URI:
             return URIType.INSTANCE
         return URIType.FRAME
 
+    @property
+    def permissive(self) -> bool:
+        """Returns the ``permissive`` parameter value in the initializer."""
+        return self._permissive
+
     def base_uri(self) -> 'URI':
         """Returns `URI` for the DICOM Service within this object."""
         return URI(self.base_url)
@@ -262,7 +267,8 @@ class URI:
                series_instance_uid: Optional[str] = None,
                sop_instance_uid: Optional[str] = None,
                frames: Optional[Sequence[int]] = None,
-               suffix: Optional[URISuffix] = None) -> 'URI':
+               suffix: Optional[URISuffix] = None,
+               permissive: Optional[bool] = False) -> 'URI':
         """Creates a new `URI` object based on the current one.
 
         Replaces the specified `URI` components in the current `URI` to create
@@ -288,6 +294,9 @@ class URI:
         suffix: URISuffix, optional
             Suffix to use in the new `URI` or `None` if the `suffix` from the
             current `URI` should be used.
+        permissive: bool, optional
+            Set if permissive handling of UIDs (if any) in the updated ``URI``
+            is required. See the class initializer docstring for details.
 
         Returns
         -------
@@ -311,6 +320,7 @@ class URI:
             if sop_instance_uid is not None else self.sop_instance_uid,
             frames if frames is not None else self.frames,
             suffix if suffix is not None else self.suffix,
+            permissive if permissive is not None else self.permissive,
         )
 
     @property
@@ -367,7 +377,8 @@ class URI:
     @classmethod
     def from_string(cls,
                     dicomweb_uri: str,
-                    uri_type: Optional[URIType] = None) -> 'URI':
+                    uri_type: Optional[URIType] = None,
+                    permissive: bool = False) -> 'URI':
         """Parses the string to return the URI.
 
         Any valid DICOMweb compatible HTTP[S] URI is permitted, e.g.,
@@ -381,6 +392,9 @@ class URI:
             The expected DICOM resource type referenced by the object. If set,
             it validates that the resource-scope of the `dicomweb_uri` matches
             the expected type.
+        permissive: bool
+            Set if permissive handling of UIDs (if any) in ``dicomweb_uri`` is
+            required. See the class initializer docstring for details.
 
         Returns
         -------
@@ -442,7 +456,7 @@ class URI:
                         f'URI: {dicomweb_uri!r}')
 
         uri = cls(base_url, study_instance_uid, series_instance_uid,
-                  sop_instance_uid, frames, suffix)
+                  sop_instance_uid, frames, suffix, permissive)
         # Validate that the URI is of the specified type, if applicable.
         if uri_type is not None and uri.type != uri_type:
             raise ValueError(

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -432,6 +432,27 @@ def test_update(uri_args, update_args, expected_uri_args):
     assert actual_uri == expected_uri
 
 
+@pytest.mark.parametrize('original,update,expected', [
+    (None, None, False),
+    (None, False, False),
+    (None, True, True),
+    (False, None, False),
+    (True, None, True),
+    (False, False, False),
+    (False, True, True),
+    (True, False, False),
+    (True, True, True),
+])
+def test_update_permissive(original, update, expected):
+    """Tests for the expected value of `permissive` flag in `URI.update()`."""
+    if original is None:
+        original_uri = URI(_BASE_URL)
+    else:
+        original_uri = URI(_BASE_URL, permissive=original)
+    updated_uri = original_uri.update(permissive=update)
+    assert updated_uri.permissive == expected
+
+
 @pytest.mark.parametrize('uri_args,update_args,error_msg', [
     ((_BASE_URL, ), (None, None, '1', None, None),
      '`study_instance_uid` missing'),

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -18,22 +18,22 @@ _FRAME_URI = f'{_INSTANCE_URI}/frames/{",".join(str(f) for f in _FRAMES)}'
 @pytest.mark.parametrize('illegal_char', ['/', '@', 'a', 'A'])
 def test_uid_illegal_character(illegal_char):
     """Checks *ValueError* is raised when a UID contains an illegal char."""
-    with pytest.raises(ValueError, match='must match'):
+    with pytest.raises(ValueError, match='in conformance'):
         URI(_BASE_URL, f'1.2{illegal_char}3')
-    with pytest.raises(ValueError, match='must match'):
+    with pytest.raises(ValueError, match='in conformance'):
         URI(_BASE_URL, '1.2.3', f'4.5{illegal_char}6')
-    with pytest.raises(ValueError, match='must match'):
+    with pytest.raises(ValueError, match='in conformance'):
         URI(_BASE_URL, '1.2.3', '4.5.6', f'7.8{illegal_char}9')
 
 
 @pytest.mark.parametrize('illegal_uid', ['.23', '1.2..4', '1.2.', '.'])
 def test_uid_illegal_format(illegal_uid):
     """Checks *ValueError* is raised if a UID is in an illegal format."""
-    with pytest.raises(ValueError, match='must match'):
+    with pytest.raises(ValueError, match='in conformance'):
         URI(_BASE_URL, illegal_uid)
-    with pytest.raises(ValueError, match='must match'):
+    with pytest.raises(ValueError, match='in conformance'):
         URI(_BASE_URL, '1.2.3', illegal_uid)
-    with pytest.raises(ValueError, match='must match'):
+    with pytest.raises(ValueError, match='in conformance'):
         URI(_BASE_URL, '1.2.3', '4.5.6', illegal_uid)
 
 
@@ -53,6 +53,21 @@ def test_uid_length():
         URI(_BASE_URL, '1.2.3', uid_65)
     with pytest.raises(ValueError, match='UID cannot have more'):
         URI(_BASE_URL, '1.2.3', '4.5.6', uid_65)
+
+
+@pytest.mark.parametrize('uid', ['13-abc', 'hello', 'is it', 'me you\'re'])
+def test_uid_permissive_valid(uid):
+    """Tests valid "permissive" UIDs are accommodated iff the flag is set."""
+    with pytest.raises(ValueError, match='in conformance'):
+        URI(_BASE_URL, uid, permissive=False)
+    URI(_BASE_URL, uid, permissive=True)
+
+
+@pytest.mark.parametrize('uid', ['1.23.5@', '1/23.4'])
+def test_uid_permissive_invalid(uid):
+    """Tests that invalid "permissive" UIDs are rejected."""
+    with pytest.raises(ValueError, match='Permissive mode'):
+        URI(_BASE_URL, uid, permissive=True)
 
 
 def test_uid_missing_error():


### PR DESCRIPTION
Good evening, Markus - per our offline conversation, I've included support for permissive handling of UIDs in `URI`. This is done via a `permissive` initializer flag, which is disabled by default. A clear warning to discourage its use is included in the docstring.

I look forward to your feedback!﻿
