### PR TITLE
fix(orthanc): can't store a instance

### DIFF
--- a/src/dicomweb_client/api.py
+++ b/src/dicomweb_client/api.py
@@ -1566,7 +1566,7 @@ class DICOMwebClient(object):
         content_type = (
             'multipart/related; '
             'type="application/dicom"; '
-            'boundary="0f3cf5c0-70e0-41ef-baef-c6f9f65ec3e1"'
+            'boundary=0f3cf5c0-70e0-41ef-baef-c6f9f65ec3e1'
         )
         content = self._encode_multipart_message(data, content_type)
         response = self._http_post(


### PR DESCRIPTION
1. Usually the quotation marks is not required
2. The Orthanc can't store the instance if the quotation marks provided and Orthanc give a sucess response(This may be a bug of Orthanc-dicomweb-plugins)